### PR TITLE
Fix wrong folder name in backend running instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Install SpiceDL from Spicetify marketplace or [releases](https://github.com/FoxR
 
 You can execute python backend by running following commands
 ```bash
-cd api-python-multiplatform
+cd api
 pip install -r requirements.txt
 pip install spotdl
 python app.py


### PR DESCRIPTION
Fixed the README instructions for running the backend server.